### PR TITLE
fix: enforce tenant isolation across all blueprints (multi-tenant stage 2)

### DIFF
--- a/app/blueprints/__init__.py
+++ b/app/blueprints/__init__.py
@@ -9,5 +9,7 @@ def create_blueprints():
     from .discussion import discussion_bp
     from .issues import issues_bp
     from .admin import admin_bp
-    
-    return [main_bp, auth_bp, courses_bp, quiz_bp, discussion_bp, issues_bp, admin_bp]
+    from .superadmin import superadmin_bp
+    from .tickets import tickets_bp
+
+    return [main_bp, auth_bp, courses_bp, quiz_bp, discussion_bp, issues_bp, admin_bp, superadmin_bp, tickets_bp]

--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -1,9 +1,10 @@
 from flask import Blueprint, render_template, request, jsonify, abort
 import re
 from flask_login import login_required, current_user
-from app.models import db, User, UserRole, ActivityLog, Course, QuizSubmission
+from app.models import db, User, UserRole, ActivityLog, Course, AcademicYear, QuizSubmission, Quiz
 from app.helpers import log_activity, sanitize_text, is_valid_email, generate_random_password
 from sqlalchemy import func
+from app.tenant import get_school_id_or_abort
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
 
@@ -12,26 +13,30 @@ admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
 def admin_required():
     if current_user.role != UserRole.ADMIN:
         abort(403)
+    if not current_user.school_id:
+        abort(403, description='Akun admin tidak terhubung ke sekolah')
 
 @admin_bp.route('/dashboard')
 def dashboard():
-    # Statistics
+    school_id = current_user.school_id
+    # Statistics - filtered by school
     stats = {
-        'total_guru': User.query.filter_by(role=UserRole.GURU).count(),
-        'total_murid': User.query.filter_by(role=UserRole.MURID).count(),
-        'total_courses': Course.query.count(),
-        'total_submissions': QuizSubmission.query.count()
+        'total_guru': User.query.filter_by(role=UserRole.GURU, school_id=school_id).count(),
+        'total_murid': User.query.filter_by(role=UserRole.MURID, school_id=school_id).count(),
+        'total_courses': Course.query.join(AcademicYear).filter(AcademicYear.school_id == school_id).count(),
+        'total_submissions': QuizSubmission.query.join(Quiz).join(Course).join(AcademicYear).filter(AcademicYear.school_id == school_id).count()
     }
-    
-    # Recent Activities
-    recent_logs = ActivityLog.query.order_by(ActivityLog.created_at.desc()).limit(20).all()
-    
+
+    # Recent Activities - filtered by school
+    recent_logs = ActivityLog.query.filter_by(school_id=school_id).order_by(ActivityLog.created_at.desc()).limit(20).all()
+
     return render_template('admin_dashboard.html', stats=stats, recent_logs=recent_logs)
 
 @admin_bp.route('/users')
 def user_management():
-    gurus = User.query.filter_by(role=UserRole.GURU).order_by(User.name).all()
-    murids = User.query.filter_by(role=UserRole.MURID).order_by(User.name).all()
+    school_id = current_user.school_id
+    gurus = User.query.filter_by(role=UserRole.GURU, school_id=school_id).order_by(User.name).all()
+    murids = User.query.filter_by(role=UserRole.MURID, school_id=school_id).order_by(User.name).all()
     return render_template('admin_users.html', gurus=gurus, murids=murids)
 
 @admin_bp.route('/api/users/bulk-import', methods=['POST'])
@@ -91,7 +96,7 @@ def bulk_import_users():
                 continue
             
             password = generate_random_password(4)
-            user = User(name=entry['name'], email=entry['email'], role=role)
+            user = User(name=entry['name'], email=entry['email'], role=role, school_id=current_user.school_id)
             user.set_password(password)
             db.session.add(user)
             
@@ -115,7 +120,10 @@ def reset_password(user_id):
     user = db.session.get(User, user_id)
     if not user:
         return jsonify({'success': False, 'message': 'User tidak ditemukan'}), 404
-        
+
+    if user.school_id != current_user.school_id:
+        return jsonify({'success': False, 'message': 'Tidak memiliki izin'}), 403
+
     data = request.get_json() or {}
     new_password = data.get('password', '').strip()
     
@@ -133,7 +141,10 @@ def toggle_user_status(user_id):
     user = db.session.get(User, user_id)
     if not user:
         return jsonify({'success': False, 'message': 'User tidak ditemukan'}), 404
-        
+
+    if user.school_id != current_user.school_id:
+        return jsonify({'success': False, 'message': 'Tidak memiliki izin'}), 403
+
     if user.id == current_user.id:
         return jsonify({'success': False, 'message': 'Anda tidak dapat menonaktifkan akun sendiri'}), 400
         

--- a/app/blueprints/courses.py
+++ b/app/blueprints/courses.py
@@ -6,6 +6,7 @@ from werkzeug.utils import secure_filename
 from sqlalchemy.orm import joinedload, selectinload
 from app.models import db, Course, AcademicYear, UserRole, Link, File, Discussion, Post, Like, UserCourseOrder
 from app.helpers import sanitize_text, is_valid_color, is_valid_class_code, generate_class_code, get_courses_for_user, format_course_data, log_activity
+from app.tenant import get_school_id_or_abort, verify_course_in_school, verify_academic_year_in_school
 
 courses_bp = Blueprint('courses', __name__, url_prefix='/api')
 
@@ -13,11 +14,11 @@ courses_bp = Blueprint('courses', __name__, url_prefix='/api')
 @courses_bp.route('/initial-data', methods=['GET'])
 @login_required
 def api_initial_data():
-    # Only use the current academic year 2025/2026
-    current_year = AcademicYear.query.filter_by(year='2025/2026').first()
+    school_id = get_school_id_or_abort()
+    # Only use the current academic year 2025/2026, scoped to school
+    current_year = AcademicYear.query.filter_by(year='2025/2026', school_id=school_id).first()
     if not current_year:
-        # Create it if it doesn't exist to prevent errors
-        current_year = AcademicYear(year='2025/2026', is_active=True)
+        current_year = AcademicYear(year='2025/2026', is_active=True, school_id=school_id)
         db.session.add(current_year)
         db.session.commit()
     
@@ -34,6 +35,8 @@ def api_initial_data():
 @courses_bp.route('/courses/year/<int:year_id>', methods=['GET'])
 @login_required
 def api_get_courses_by_year(year_id):
+    school_id = get_school_id_or_abort()
+    verify_academic_year_in_school(year_id, school_id)
     courses_query = get_courses_for_user(current_user, year_id)
     courses = [format_course_data(c, current_user) for c in courses_query]
     return jsonify({'courses': courses})
@@ -54,6 +57,9 @@ def api_create_course():
     except Exception:
         return jsonify({'success': False, 'message': 'Tahun ajaran tidak valid'}), 400
 
+    school_id = get_school_id_or_abort()
+    verify_academic_year_in_school(academic_year_id, school_id)
+
     new_course = Course(
         name=name,
         academic_year_id=academic_year_id,
@@ -72,6 +78,8 @@ def update_course(course_id):
     course = db.session.get(Course, course_id)
     if course is None:
         abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     if course.teacher_id != current_user.id:
         abort(403, description="Anda tidak memiliki izin untuk mengedit kelas ini.")
     data = request.get_json() or {}
@@ -95,7 +103,10 @@ def api_delete_course(course_id):
     course = db.session.get(Course, course_id)
     if not course:
         return jsonify({'success': False, 'message': 'Kelas tidak ditemukan'}), 404
-    
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
+
     if course.teacher_id != current_user.id:
         return jsonify({'success': False, 'message': 'Anda tidak memiliki izin untuk menghapus kelas ini'}), 403
     
@@ -134,6 +145,11 @@ def api_enroll_in_course():
     course_to_join = Course.query.filter_by(class_code=code).first()
     if not course_to_join:
         return jsonify({'success': False, 'message': f'Kelas dengan kode "{code}" tidak ditemukan'}), 404
+
+    # Verify course belongs to student's school
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course_to_join, school_id)
+
     if course_to_join in current_user.courses_enrolled:
         return jsonify({'success': False, 'message': 'Anda sudah terdaftar di kelas ini'}), 409
     current_user.courses_enrolled.append(course_to_join)
@@ -157,6 +173,9 @@ def api_create_link(course_id):
     course = db.session.get(Course, course_id)
     if not course:
         return jsonify({'success': False, 'message': 'Mata pelajaran tidak ditemukan'}), 404
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
 
     # 3. Validasi Keamanan: Pastikan guru ini adalah pemilik mata pelajaran
     if course.teacher_id != current_user.id:
@@ -212,6 +231,9 @@ def api_create_file(course_id):
     course = db.session.get(Course, course_id)
     if not course:
         return jsonify({'success': False, 'message': 'Mata pelajaran tidak ditemukan'}), 404
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
 
     if course.teacher_id != current_user.id:
         return jsonify({'success': False, 'message': 'Anda tidak memiliki izin untuk mengunggah file di mata pelajaran ini'}), 403
@@ -286,6 +308,9 @@ def create_discussion(course_id):
     if not course:
         return jsonify({'success': False, 'message': 'Mata pelajaran tidak ditemukan'}), 404
 
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
+
     if current_user.role != UserRole.GURU and current_user not in course.students:
         return jsonify({'success': False, 'message': 'Anda tidak memiliki izin untuk membuat diskusi di kelas ini'}), 403
 
@@ -325,6 +350,9 @@ def get_discussions(course_id):
     course = db.session.get(Course, course_id)
     if not course:
         return jsonify({'success': False, 'message': 'Mata pelajaran tidak ditemukan'}), 404
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
 
     if current_user.role != UserRole.GURU and current_user not in course.students:
         return jsonify({'success': False, 'message': 'Anda tidak memiliki izin untuk melihat diskusi di kelas ini'}), 403

--- a/app/blueprints/discussion.py
+++ b/app/blueprints/discussion.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify, abort
 from flask_login import login_required, current_user
 from app.models import db, Post, Discussion
 from app.helpers import sanitize_text
+from app.tenant import get_school_id_or_abort, verify_course_in_school
 
 discussion_bp = Blueprint('discussion', __name__, url_prefix='/api')
 
@@ -14,6 +15,9 @@ def api_delete_post(post_id):
 
     discussion = post.discussion
     course = discussion.course
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
 
     is_teacher = current_user.id == course.teacher_id
     is_discussion_creator = current_user.id == discussion.user_id
@@ -32,6 +36,9 @@ def api_edit_post(post_id):
     post = db.session.get(Post, post_id)
     if not post:
         abort(404, description="Postingan tidak ditemukan.")
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(post.discussion.course, school_id)
 
     if current_user.id != post.user_id:
         abort(403, description="Anda tidak memiliki izin untuk mengedit postingan ini.")

--- a/app/blueprints/issues.py
+++ b/app/blueprints/issues.py
@@ -2,6 +2,7 @@ from flask import Blueprint, request, jsonify, abort
 from flask_login import login_required, current_user
 from app.models import db, Issue, IssueStatus, IssuePriority, UserRole
 from app.helpers import sanitize_text
+from app.tenant import get_school_id_or_abort
 
 issues_bp = Blueprint('issues', __name__, url_prefix='/api')
 
@@ -9,12 +10,13 @@ issues_bp = Blueprint('issues', __name__, url_prefix='/api')
 @login_required
 def get_issues():
     status_filter = request.args.get('status')
-    
-    # Murid only see their own, Admin/Guru see all
+    school_id = get_school_id_or_abort()
+
+    # Murid only see their own, Admin/Guru see their school's
     if current_user.role == UserRole.MURID:
-        query = Issue.query.filter(Issue.user_id == current_user.id)
+        query = Issue.query.filter(Issue.user_id == current_user.id, Issue.school_id == school_id)
     else:
-        query = Issue.query
+        query = Issue.query.filter(Issue.school_id == school_id)
     
     if status_filter == 'resolved':
         query = query.filter(Issue.status == IssueStatus.RESOLVED)
@@ -44,11 +46,13 @@ def create_issue():
     except KeyError:
         priority = IssuePriority.MEDIUM
         
+    school_id = get_school_id_or_abort()
     new_issue = Issue(
         title=title,
         description=description,
         priority=priority,
-        user_id=current_user.id
+        user_id=current_user.id,
+        school_id=school_id
     )
     
     db.session.add(new_issue)
@@ -66,10 +70,11 @@ def update_issue(issue_id):
     issue = db.session.get(Issue, issue_id)
     if not issue:
         abort(404)
-        
-    # Only owner or Admin/Guru can update status? 
-    # Usually owner can close, but Guru/Admin manages the resolution.
-    # For now, allow owner to edit content, but only Guru/Admin can change status to In Progress etc.
+
+    school_id = get_school_id_or_abort()
+    if issue.school_id != school_id:
+        abort(403)
+
     is_owner = issue.user_id == current_user.id
     is_privileged = current_user.role in [UserRole.GURU, UserRole.ADMIN]
     
@@ -106,7 +111,11 @@ def delete_issue(issue_id):
     issue = db.session.get(Issue, issue_id)
     if not issue:
         abort(404)
-        
+
+    school_id = get_school_id_or_abort()
+    if issue.school_id != school_id:
+        abort(403)
+
     # Only owner or Admin can delete
     if issue.user_id != current_user.id and current_user.role != UserRole.ADMIN:
         return jsonify({'success': False, 'message': 'Anda tidak memiliki izin'}), 403

--- a/app/blueprints/main.py
+++ b/app/blueprints/main.py
@@ -7,6 +7,7 @@ from app.models import (
     QuizSubmission, Answer, Discussion
 )
 from app.helpers import get_jakarta_now
+from app.tenant import get_school_id_or_abort, verify_course_in_school
 
 main_bp = Blueprint('main', __name__)
 
@@ -27,6 +28,8 @@ def course_detail(course_id):
     course = db.session.get(Course, course_id)
     if course is None:
         abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     is_teacher = (current_user.id == course.teacher_id)
     
     quizzes = Quiz.query.filter_by(course_id=course.id).all()
@@ -76,6 +79,8 @@ def quiz_detail(quiz_id):
         abort(404)
 
     course = quiz.course
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     is_teacher = (current_user.id == course.teacher_id)
     is_preview = request.args.get('preview') == 'true'
 
@@ -114,6 +119,8 @@ def serve_file(file_id):
         abort(404)
 
     course = file.course
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     is_teacher = (current_user.id == course.teacher_id)
 
     if not is_teacher and current_user not in course.students:
@@ -134,6 +141,8 @@ def serve_question_image(course_id, filename):
     course = db.session.get(Course, course_id)
     if course is None:
         abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     is_teacher = (current_user.id == course.teacher_id)
     is_student = current_user in course.students
     if not is_teacher and not is_student:
@@ -147,6 +156,8 @@ def discussion_detail(course_id, discussion_id):
     course = db.session.get(Course, course_id)
     if course is None:
         abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(course, school_id)
     discussion = db.session.get(Discussion, discussion_id)
     if discussion is None or discussion.course_id != course_id:
         abort(404)

--- a/app/blueprints/quiz.py
+++ b/app/blueprints/quiz.py
@@ -18,15 +18,21 @@ quiz_bp = Blueprint('quiz', __name__, url_prefix='/api')
 # --- Helper Functions ---
 
 def get_quiz_or_abort(quiz_id, check_teacher=True):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     quiz = db.session.get(Quiz, quiz_id)
     if not quiz: abort(404, description="Kuis tidak ditemukan.")
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(quiz.course, school_id)
     if check_teacher and quiz.course.teacher_id != current_user.id:
         abort(403, description="Anda tidak memiliki akses ke kuis ini.")
     return quiz
 
 def get_question_or_abort(question_id, check_teacher=True):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     question = db.session.get(Question, question_id)
     if not question: abort(404, description="Pertanyaan tidak ditemukan.")
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(question.quiz.course, school_id)
     if check_teacher and question.quiz.course.teacher_id != current_user.id:
         abort(403, description="Anda tidak memiliki akses ke pertanyaan ini.")
     return question
@@ -203,8 +209,13 @@ def api_add_option(question_id):
 @quiz_bp.route('/option/<int:option_id>/update', methods=['PUT'])
 @login_required
 def api_update_option(option_id):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     option = db.session.get(Option, option_id)
     if not option: abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(option.question.quiz.course, school_id)
+    if option.question.quiz.course.teacher_id != current_user.id:
+        abort(403)
     option.option_text = sanitize_text(request.form.get('option_text', ''))
     db.session.commit()
     return f'<input type="text" class="option-input" value="{option.option_text}" name="option_text" hx-put="/api/option/{option.id}/update" hx-trigger="blur" hx-swap="outerHTML" placeholder="Opsi {option.order}" />'
@@ -212,7 +223,13 @@ def api_update_option(option_id):
 @quiz_bp.route('/option/<int:option_id>/delete', methods=['DELETE'])
 @login_required
 def api_delete_option(option_id):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     option = db.session.get(Option, option_id)
+    if not option: return "", 200
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(option.question.quiz.course, school_id)
+    if option.question.quiz.course.teacher_id != current_user.id:
+        abort(403)
     if option and option.question.options.count() > 1:
         db.session.delete(option)
         db.session.commit()
@@ -240,10 +257,14 @@ def api_set_quiz_status(quiz_id):
 @quiz_bp.route('/submission/<int:submission_id>')
 @login_required
 def api_get_submission(submission_id):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     submission = db.session.get(QuizSubmission, submission_id)
     if not submission:
         abort(404)
-    
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(submission.quiz.course, school_id)
+
     is_teacher = submission.quiz.course.teacher_id == current_user.id
     if not is_teacher and submission.user_id != current_user.id:
         abort(403)
@@ -253,8 +274,13 @@ def api_get_submission(submission_id):
 @quiz_bp.route('/submission/<int:submission_id>/update-score', methods=['POST'])
 @login_required
 def api_update_submission_score(submission_id):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     submission = db.session.get(QuizSubmission, submission_id)
-    if not submission or submission.quiz.course.teacher_id != current_user.id:
+    if not submission:
+        abort(404)
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(submission.quiz.course, school_id)
+    if submission.quiz.course.teacher_id != current_user.id:
         abort(403)
     
     data = request.get_json()
@@ -422,10 +448,14 @@ def api_remove_question_image(question_id):
 @quiz_bp.route('/quiz/<int:quiz_id>/submit', methods=['POST'])
 @login_required
 def api_submit_quiz(quiz_id):
+    from app.tenant import get_school_id_or_abort, verify_course_in_school
     quiz = db.session.get(Quiz, quiz_id)
     if not quiz:
         abort(404, description="Kuis tidak ditemukan.")
-    
+
+    school_id = get_school_id_or_abort()
+    verify_course_in_school(quiz.course, school_id)
+
     # Handle both JSON and FormData
     if request.is_json:
         data = request.get_json()

--- a/app/blueprints/tickets.py
+++ b/app/blueprints/tickets.py
@@ -82,7 +82,7 @@ def api_create_ticket(slug):
         priority = TicketPriority.MEDIUM
 
     ticket = Ticket(
-        ticket_number=generate_ticket_number(),
+        ticket_number=generate_ticket_number(school_id=current_user.school_id),
         title=title,
         description=description,
         category=category,
@@ -164,6 +164,9 @@ def api_close_ticket(slug, ticket_id):
     ticket = db.session.get(Ticket, ticket_id)
     if not ticket:
         return jsonify({'success': False, 'message': 'Ticket tidak ditemukan'}), 404
+
+    if ticket.school_id != current_user.school_id:
+        return jsonify({'success': False, 'message': 'Tidak memiliki izin'}), 403
 
     if ticket.user_id != current_user.id and current_user.role not in (UserRole.ADMIN, UserRole.SUPER_ADMIN):
         return jsonify({'success': False, 'message': 'Tidak memiliki izin'}), 403

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -11,17 +11,25 @@ def get_jakarta_now():
     """Returns current time in Jakarta (WIB, UTC+7)."""
     return datetime.now(timezone(timedelta(hours=7)))
 
-def log_activity(user_id, action, target_type=None, target_id=None, details=None):
+def log_activity(user_id, action, target_type=None, target_id=None, details=None, school_id=None):
     """Logs user activity in the database."""
     from app.models import db, ActivityLog
     try:
+        # Auto-detect school_id from user if not provided
+        if school_id is None:
+            from app.models import User
+            user = db.session.get(User, user_id)
+            if user:
+                school_id = user.school_id
+
         log = ActivityLog(
             user_id=user_id,
             action=action,
             target_type=target_type,
             target_id=target_id,
             details=details,
-            ip_address=request.remote_addr if request else '127.0.0.1'
+            ip_address=request.remote_addr if request else '127.0.0.1',
+            school_id=school_id
         )
         db.session.add(log)
         db.session.commit()

--- a/app/models/issue.py
+++ b/app/models/issue.py
@@ -26,7 +26,10 @@ class Issue(db.Model):
     
     # Relationships
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    school_id = db.Column(db.Integer, db.ForeignKey('schools.id'), nullable=True, index=True)
+
     user = db.relationship('User', backref=db.backref('issues', lazy=True))
+    school = db.relationship('School', backref=db.backref('issues', lazy=True))
     
     created_at = db.Column(db.DateTime, default=get_jakarta_now)
     updated_at = db.Column(db.DateTime, default=get_jakarta_now, onupdate=get_jakarta_now)
@@ -39,6 +42,7 @@ class Issue(db.Model):
             'status': self.status.value,
             'priority': self.priority.value,
             'user_id': self.user_id,
+            'school_id': self.school_id,
             'user_name': self.user.name,
             'created_at': self.created_at.strftime('%Y-%m-%d %H:%M:%S'),
             'updated_at': self.updated_at.strftime('%Y-%m-%d %H:%M:%S')

--- a/app/services/ticket_service.py
+++ b/app/services/ticket_service.py
@@ -4,13 +4,14 @@ from app.models import Ticket, TicketStatus, TicketMessage, UserRole
 from app.helpers import get_jakarta_now
 
 
-def generate_ticket_number():
+def generate_ticket_number(school_id=None):
     now = get_jakarta_now()
     year = now.strftime('%Y')
 
-    last_ticket = Ticket.query.filter(
-        Ticket.ticket_number.like(f'TKT-{year}-%')
-    ).order_by(Ticket.id.desc()).first()
+    query = Ticket.query.filter(Ticket.ticket_number.like(f'TKT-{year}-%'))
+    if school_id:
+        query = query.filter(Ticket.school_id == school_id)
+    last_ticket = query.order_by(Ticket.id.desc()).first()
 
     if last_ticket:
         try:
@@ -69,6 +70,7 @@ def get_queue_position(ticket):
 
     count = Ticket.query.filter(
         Ticket.status.in_([TicketStatus.OPEN, TicketStatus.IN_QUEUE]),
+        Ticket.school_id == ticket.school_id,
         Ticket.created_at < ticket.created_at,
     ).count()
 

--- a/app/tenant.py
+++ b/app/tenant.py
@@ -1,0 +1,32 @@
+from flask import abort
+from flask_login import current_user
+
+
+def get_school_id_or_abort():
+    """Get the current user's school_id, or abort 403 if not set."""
+    school_id = current_user.school_id
+    if not school_id:
+        abort(403, description='Akun tidak terhubung ke sekolah manapun')
+    return school_id
+
+
+def verify_user_in_school(user, school_id):
+    """Verify that a given user belongs to the specified school."""
+    if user.school_id != school_id:
+        abort(403, description='Tidak memiliki izin untuk mengakses user ini')
+
+
+def verify_course_in_school(course, school_id):
+    """Verify that a course belongs to the specified school via its academic year."""
+    if not course.academic_year or course.academic_year.school_id != school_id:
+        abort(403, description='Kelas tidak ditemukan di sekolah ini')
+
+
+def verify_academic_year_in_school(year_id, school_id):
+    """Verify an academic year belongs to the school."""
+    from app.models import AcademicYear
+    from app.extensions import db
+    year = db.session.get(AcademicYear, year_id)
+    if not year or year.school_id != school_id:
+        abort(400, description='Tahun ajaran tidak valid untuk sekolah ini')
+    return year

--- a/migrations/versions/c1a2b3d4e5f6_add_school_id_to_issues.py
+++ b/migrations/versions/c1a2b3d4e5f6_add_school_id_to_issues.py
@@ -1,0 +1,34 @@
+"""add school_id to issues table
+
+Revision ID: c1a2b3d4e5f6
+Revises: ac94c9116a87
+Create Date: 2026-03-10 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c1a2b3d4e5f6'
+down_revision = 'ac94c9116a87'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Step 1: Add school_id as nullable
+    op.add_column('issues', sa.Column('school_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_issues_school_id'), 'issues', ['school_id'], unique=False)
+    op.create_foreign_key('fk_issues_school_id', 'issues', 'schools', ['school_id'], ['id'])
+
+    # Step 2: Backfill school_id from users table
+    op.execute(
+        "UPDATE issues SET school_id = (SELECT school_id FROM users WHERE users.id = issues.user_id)"
+    )
+
+
+def downgrade():
+    op.drop_constraint('fk_issues_school_id', 'issues', type_='foreignkey')
+    op.drop_index(op.f('ix_issues_school_id'), table_name='issues')
+    op.drop_column('issues', 'school_id')


### PR DESCRIPTION
## Summary
- **Critical security fix**: Closes all cross-tenant data leakage vulnerabilities left after multi-tenant stage 1
- Adds `app/tenant.py` reusable helper module with `get_school_id_or_abort()`, `verify_course_in_school()`, `verify_user_in_school()`, `verify_academic_year_in_school()`
- Adds `school_id` column to Issue model with migration + backfill from users table
- Scopes admin dashboard stats, user management, bulk import, password reset, and user toggle by `school_id`
- Prevents cross-school enrollment via class code
- Adds school validation to all course, quiz, discussion, file, and ticket routes
- Scopes ticket numbering and queue position per school
- Auto-detects `school_id` in `log_activity()` helper
- Registers missing `tickets_bp` and `superadmin_bp` in blueprint `__init__.py`

## Files changed (13)
| File | Change |
|------|--------|
| `app/tenant.py` | **NEW** - Central tenant isolation helpers |
| `app/models/issue.py` | Add `school_id` column + relationship |
| `app/blueprints/__init__.py` | Register tickets + superadmin blueprints |
| `app/blueprints/admin.py` | School-scope all queries + user checks |
| `app/blueprints/courses.py` | School validation on all routes |
| `app/blueprints/discussion.py` | School validation on post operations |
| `app/blueprints/issues.py` | Filter all queries by school_id |
| `app/blueprints/main.py` | School validation on page routes |
| `app/blueprints/quiz.py` | School validation in helpers + routes |
| `app/blueprints/tickets.py` | School check on close + scoped numbering |
| `app/helpers.py` | Auto-detect school_id in log_activity |
| `app/services/ticket_service.py` | Scope ticket numbering + queue per school |
| `migrations/versions/c1a2b3d4e5f6_...` | **NEW** - Add school_id to issues table |

## Test plan
- [x] Login as Admin Sekolah A → verify dashboard only shows Sekolah A data
- [x] Bulk import users → verify new users have correct school_id
- [x] Try reset password of user from another school → should get 403
- [x] Try enroll to course from another school via class code → should get 403
- [x] Create issue → verify issue has school_id set
- [x] Check ticket queue position → should count per school only
- [x] Run `flask db upgrade` to apply Issue.school_id migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)